### PR TITLE
Force the Apt key ID to match expectations

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,7 @@
 
 - name: Adding APT key
   apt_key:
+    id: 548C16BF
     url: https://download.newrelic.com/548C16BF.gpg
 
 - name: Add APT repository


### PR DESCRIPTION
I know it's perhaps a little paranoid, but I prefer to validate the ID of the supplied key
