### PR TITLE
Default groups [] breaks install when docker monitoring is enabled.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,6 +14,6 @@
 - name: Configuring user groups
   user:
     name: "{{ newrelic_user }}"
-    groups: "{{ newrelic_groups }}"
+    groups: "{{ newrelic_groups|join(',') }}"
     append: yes
   when: not newrelic_disable_docker


### PR DESCRIPTION
Ansible version: ansible 1.9.5
OS: Mac OS X El Capitan 10.11.4

When newrelic_disable_docker is set to `no` and `newrelic_groups` is left with the default value of `[]`, this breaks the install because ansible expects `groups` to take in a comma-delimited string of groups, and not `[]`.

So I just set the default value to `''`, which should work.  Also, added some notes regarding docker container monitoring.  In my installation of docker, the docker group does not exist, but I just set it to `root` and container monitoring works fine.
