### PR TITLE
Override hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ newrelic_disable_docker: yes
 newrelic_service_enabled: yes
 # current state: started, stopped
 newrelic_service_state: started
+# use default hostname, set a valute to override the default hostname
+newrelic_override_hostname: ~
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ newrelic_disable_docker: yes
 newrelic_service_enabled: yes
 # current state: started, stopped
 newrelic_service_state: started
-# use default hostname, set a valute to override the default hostname
+# use default hostname, set a value to override the default hostname
 newrelic_override_hostname: ~
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ newrelic_disable_docker: yes
 newrelic_service_enabled: yes
 # current state: started, stopped
 newrelic_service_state: started
+# use default hostname, set a valute to override the default hostname
+newrelic_override_hostname: ~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,5 +20,5 @@ newrelic_disable_docker: yes
 newrelic_service_enabled: yes
 # current state: started, stopped
 newrelic_service_state: started
-# use default hostname, set a valute to override the default hostname
+# use default hostname, set a value to override the default hostname
 newrelic_override_hostname: ~

--- a/templates/etc/newrelic/nrsysmond.cfg.j2
+++ b/templates/etc/newrelic/nrsysmond.cfg.j2
@@ -203,3 +203,13 @@ disable_nfs={{ newrelic_disable_nfs | to_nice_json }}
 # Default: false
 #
 disable_docker={{ newrelic_disable_docker | to_nice_json }}
+
+{% if newrelic_override_hostname %}
+#
+# Option : override_hostname
+# Type   : string
+# Value  : Set to a non-empty value to use as the hostname that will be reported to New Relic
+# Default: none
+#
+hostname={{ newrelic_override_hostname }}
+{% endif %}


### PR DESCRIPTION
Add the option to override the hostname reported to newrelic, following the guideline set in the documentation: https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/change-linux-server-name
This is useful if you have many hostnames that are non-descriptive.
