### PR TITLE
add newrelic proxy options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,5 @@ newrelic_service_state: started
 newrelic_override_hostname: ~
 # A series of label_type/label_value pairings: label_type:label_value
 newrelic_labels: ~
+# proxy server to use
+#newrelic_proxy: proxy-host:8080

--- a/templates/etc/newrelic/nrsysmond.cfg.j2
+++ b/templates/etc/newrelic/nrsysmond.cfg.j2
@@ -52,7 +52,11 @@ logfile={{ newrelic_logfile }}
 #            fred:secret@proxy.mydomain.com:8181
 # Default: none (use a direct connection)
 #
+{% if newrelic_proxy is defined %}
+proxy={{ newrelic_proxy }}
+{% else %}
 #proxy=
+{% endif %}
 
 #
 # Setting: ssl


### PR DESCRIPTION
newrelic proxy options should be available in case there is no direct connection to internet in production env/strict firewall