### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ newrelic_service_enabled: yes
 # current state: started, stopped
 newrelic_service_state: started
 # use default hostname, set a value to override the default hostname
-newrelic_override_hostname: ~
+newrelic_override_hostname:
 # A series of label_type/label_value pairings: label_type:label_value
 newrelic_labels:
 # proxy server to use (i.e. proxy-host:8080)


### PR DESCRIPTION
Remove the default hostname of "~" as the nrsysmond.cfg.j2 has 

```
#
# Option : override_hostname
# Type   : string
# Value  : Set to a non-empty value to use as the hostname that will be reported to New Relic
# Default: none
#
#hostname=newrelic.com
{% if newrelic_override_hostname|default(None) != None %}
hostname={{ newrelic_override_hostname }}
{% endif %}
```